### PR TITLE
fix: TypeScript v6 対応のため tsconfig に ignoreDeprecations と rootDir を追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -22,10 +22,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

Renovate PR #1891 (`chore(deps): update dependency typescript to v6`) が TypeScript v6 へのアップグレードにより、以下のコンパイルエラーで失敗していました。本 PR はそれらのエラーを解消するための `tsconfig.json` 修正です。

## 発生していたエラー

| エラー | 内容 |
|--------|------|
| TS5107 | `moduleResolution=node10` が TypeScript v6 で非推奨 |
| TS5101 | `baseUrl` が TypeScript v6 で非推奨 |
| TS5011 | `rootDir` が未設定 |

## 変更内容

### `tsconfig.json`

| 変更 | 理由 |
|------|------|
| `"moduleResolution": "Node"` を削除 | `module: "commonjs"` のデフォルト解決に委ねることで TS5107 を回避。明示的な `Node`/`node10` 指定時のみ TS5107 が発生するため |
| `"baseUrl": "."` を削除 | TypeScript v6 で TS5101 エラーとなるため削除 |
| `"paths"` の値を `"src/*"` → `"./src/*"` に変更 | `baseUrl` なしで `@/*` エイリアスが正しく解決されるよう、プロジェクトルート相対パスで明示指定 |
| `"rootDir": "./src"` を追加 | TS5011 エラー (`rootDir` が未設定) を解消 |

## 注意事項

`"ignoreDeprecations": "6.0"` は採用しませんでした。この値は TypeScript v5 では TS5103 エラー (`Invalid value for '--ignoreDeprecations'`) となるため、TypeScript v5 でのビルドを壊してしまいます。代わりに、deprecated な設定そのものを削除・修正する方針を採用しました。

## 動作確認

- TypeScript v5.9.3 でコンパイルエラーなしを確認
- TypeScript v6.0.3 でコンパイルエラーなしを確認
- `@/*` パスエイリアスが引き続き正しく解決されることを確認
- `src/` 配下にすべての TypeScript ソースファイルが存在し、`rootDir: "./src"` の範囲内であることを確認

## 関連

- Renovate PR: #1891 (`chore(deps): update dependency typescript to v6`)