### PR TITLE
style: reformat with prettier 3.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-n": "18.2.1",
     "eslint-plugin-promise": "7.3.0",
     "natsort": "2.0.3",
-    "prettier": "3.8.5",
+    "prettier": "3.9.4",
     "run-z": "2.1.0",
     "tsx": "4.23.0",
     "typescript": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 2.0.3
         version: 2.0.3
       prettier:
-        specifier: 3.8.5
-        version: 3.8.5
+        specifier: 3.9.4
+        version: 3.9.4
       run-z:
         specifier: 2.1.0
         version: 2.1.0
@@ -1470,8 +1470,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.5:
-    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3443,7 +3443,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.5: {}
+  prettier@3.9.4: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/src/commands/check-permissions.ts
+++ b/src/commands/check-permissions.ts
@@ -11,9 +11,7 @@ import { Discord } from '@/discord'
 
 export class CheckPermissionsCommand implements BaseCommand {
   definition():
-    | SlashCommandSubcommandBuilder
-    | SlashCommandSubcommandGroupBuilder
-    | null {
+    SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder | null {
     return new SlashCommandSubcommandBuilder()
       .setName('check-permissions')
       .setDescription(

--- a/src/commands/regenerate.ts
+++ b/src/commands/regenerate.ts
@@ -12,9 +12,7 @@ import { ListEmojis } from '@/list-emojis'
 
 export class RegenerateCommand implements BaseCommand {
   definition():
-    | SlashCommandSubcommandBuilder
-    | SlashCommandSubcommandGroupBuilder
-    | null {
+    SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder | null {
     return new SlashCommandSubcommandBuilder()
       .setName('regenerate')
       .setDescription('絵文字一覧を再生成します。')

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -12,9 +12,7 @@ import { Logger } from '@book000/node-utils'
 
 export class RegisterCommand implements BaseCommand {
   definition():
-    | SlashCommandSubcommandBuilder
-    | SlashCommandSubcommandGroupBuilder
-    | null {
+    SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder | null {
     return new SlashCommandSubcommandBuilder()
       .setName('register')
       .setDescription('このサーバを watch-guilds の対象サーバに設定します。')

--- a/src/commands/unregister.ts
+++ b/src/commands/unregister.ts
@@ -11,9 +11,7 @@ import { Logger } from '@book000/node-utils'
 
 export class UnregisterCommand implements BaseCommand {
   definition():
-    | SlashCommandSubcommandBuilder
-    | SlashCommandSubcommandGroupBuilder
-    | null {
+    SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder | null {
     return new SlashCommandSubcommandBuilder()
       .setName('unregister')
       .setDescription('このサーバの watch-guilds の対象サーバから外します。')

--- a/src/commands/update-command.ts
+++ b/src/commands/update-command.ts
@@ -11,9 +11,7 @@ import { Logger } from '@book000/node-utils'
 
 export class UpdateCommand implements BaseCommand {
   definition():
-    | SlashCommandSubcommandBuilder
-    | SlashCommandSubcommandGroupBuilder
-    | null {
+    SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder | null {
     return new SlashCommandSubcommandBuilder()
       .setName('update-commands')
       .setDescription('このサーバのコマンドを更新します。')


### PR DESCRIPTION
Renovate PR #2088 bumps `prettier` 3.8.5 -> 3.9.4, and the new prettier version reformats a union-type return annotation differently (collapses a short multi-line union onto one line) in 5 files under `src/commands/`. This broke `lint:prettier` (`prettier --check src`) on #2088.

This PR runs `prettier --write src` under the new prettier version, applying the reformatting. No behavior change -- pure formatting.

`pnpm run lint` (prettier + eslint + tsc) passes clean.

Related: #2088