### PR TITLE
fix(events): reorder sticker guard conditions for unicorn/prefer-simple-condition-first

### DIFF
--- a/src/events/sticker-create.ts
+++ b/src/events/sticker-create.ts
@@ -14,7 +14,7 @@ export class DiscordStickerCreateEvent extends BaseDiscordEvent {
 
     const server = new WatchGuildServer(guild)
     const channelId = server.getChannelId('notifier-sticker')
-    if (!server.isRegistered() || channelId === null) {
+    if (channelId === null || !server.isRegistered()) {
       return
     }
     const channel = guild.channels.cache.get(channelId)

--- a/src/events/sticker-delete.ts
+++ b/src/events/sticker-delete.ts
@@ -14,7 +14,7 @@ export class DiscordStickerDeleteEvent extends BaseDiscordEvent {
 
     const server = new WatchGuildServer(guild)
     const channelId = server.getChannelId('notifier-sticker')
-    if (!server.isRegistered() || channelId === null) {
+    if (channelId === null || !server.isRegistered()) {
       return
     }
     const channel = guild.channels.cache.get(channelId)

--- a/src/events/sticker-update.ts
+++ b/src/events/sticker-update.ts
@@ -13,7 +13,7 @@ export class DiscordStickerUpdateEvent extends BaseDiscordEvent {
 
     const server = new WatchGuildServer(guild)
     const channelId = server.getChannelId('notifier-sticker')
-    if (!server.isRegistered() || channelId === null) {
+    if (channelId === null || !server.isRegistered()) {
       return
     }
     const channel = guild.channels.cache.get(channelId)


### PR DESCRIPTION
## Summary

Renovate PR #2143 (`@book000/eslint-config` 1.16.8 → 1.16.14) fails `Node CI / node-ci (.)` lint because the new eslint-config version enables the `unicorn/prefer-simple-condition-first` rule, which flags the pre-existing guard `if (!server.isRegistered() || channelId === null)` in three sticker event handlers.

This PR reorders the condition (simple check first) in the three affected files so the codebase is compliant ahead of the eslint-config bump landing.

## Changes

- `src/events/sticker-create.ts`
- `src/events/sticker-delete.ts`
- `src/events/sticker-update.ts`

No behavior change — `||` short-circuit logic is unaffected by operand order.

---
Related: #2143 (Renovate PR bumping `@book000/eslint-config`).